### PR TITLE
Maid 1419 modify file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,25 @@ cargo test
 
 ## TODO
 ### [0.1.0]
-- [ ] [MAID-1401](https://maidsafe.atlassian.net/browse/MAID-1401) Launcher Start-up
+- [X] [MAID-1401](https://maidsafe.atlassian.net/browse/MAID-1401) Launcher Start-up
   - [X] [MAID-1402](https://maidsafe.atlassian.net/browse/MAID-1402) Self-Authenticate
-  - [ ] [MAID-1403](https://maidsafe.atlassian.net/browse/MAID-1403) Handle Session Packet
+  - [X] [MAID-1403](https://maidsafe.atlassian.net/browse/MAID-1403) Handle Session Packet
   - [X] [MAID-1404](https://maidsafe.atlassian.net/browse/MAID-1404) Threaded TCP server, Design
-  - [ ] [MAID-1405](https://maidsafe.atlassian.net/browse/MAID-1405) Implement Threaded TCP server
-  - [ ] [MAID-1406](https://maidsafe.atlassian.net/browse/MAID-1406) Test Async TCP server by writing a mock app client
-- [ ] [MAID-1407](https://maidsafe.atlassian.net/browse/MAID-1407) Launcher App Handling
-  - [ ] [MAID-1408](https://maidsafe.atlassian.net/browse/MAID-1408) Handle Adding of App
-  - [ ] [MAID-1409](https://maidsafe.atlassian.net/browse/MAID-1409) App authentication
-  - [ ] [MAID-1410](https://maidsafe.atlassian.net/browse/MAID-1410) App Removal
+  - [X] [MAID-1405](https://maidsafe.atlassian.net/browse/MAID-1405) Implement Threaded TCP server
+  - [X] [MAID-1406](https://maidsafe.atlassian.net/browse/MAID-1406) Test Async TCP server by writing a mock app client
+- [X] [MAID-1407](https://maidsafe.atlassian.net/browse/MAID-1407) Launcher App Handling
+  - [x] [MAID-1408](https://maidsafe.atlassian.net/browse/MAID-1408) Handle Adding of App
+  - [X] [MAID-1409](https://maidsafe.atlassian.net/browse/MAID-1409) App authentication
+  - [X] [MAID-1410](https://maidsafe.atlassian.net/browse/MAID-1410) App Removal
 - [ ] [MAID-1411](https://maidsafe.atlassian.net/browse/MAID-1411) Launcher provided services to apps
-  - [ ] [MAID-1412](https://maidsafe.atlassian.net/browse/MAID-1412) Design JSON dispatcher
-  - [ ] [MAID-1413](https://maidsafe.atlassian.net/browse/MAID-1413) Create Directory
-  - [ ] [MAID-1414](https://maidsafe.atlassian.net/browse/MAID-1414) Delete Directory
-  - [ ] [MAID-1415](https://maidsafe.atlassian.net/browse/MAID-1415) Modify Directory
+  - [X] [MAID-1412](https://maidsafe.atlassian.net/browse/MAID-1412) Design JSON dispatcher
+  - [X] [MAID-1413](https://maidsafe.atlassian.net/browse/MAID-1413) Create Directory
+  - [X] [MAID-1414](https://maidsafe.atlassian.net/browse/MAID-1414) Delete Directory
+  - [X] [MAID-1415](https://maidsafe.atlassian.net/browse/MAID-1415) Modify Directory
   - [ ] [MAID-1416](https://maidsafe.atlassian.net/browse/MAID-1416) Get Directory
   - [ ] [MAID-1417](https://maidsafe.atlassian.net/browse/MAID-1417) Create File
   - [ ] [MAID-1418](https://maidsafe.atlassian.net/browse/MAID-1418) Delete File
-  - [ ] [MAID-1419](https://maidsafe.atlassian.net/browse/MAID-1419) Modify File
+  - [X] [MAID-1419](https://maidsafe.atlassian.net/browse/MAID-1419) Modify File
   - [ ] [MAID-1420](https://maidsafe.atlassian.net/browse/MAID-1420) Get File
   - [ ] [MAID-1421](https://maidsafe.atlassian.net/browse/MAID-1421) Register DNS
   - [ ] [MAID-1422](https://maidsafe.atlassian.net/browse/MAID-1422) Add Service to registered DNS

--- a/src/launcher/parser/nfs/delete_dir_v1_0.rs
+++ b/src/launcher/parser/nfs/delete_dir_v1_0.rs
@@ -23,7 +23,6 @@ pub struct DeleteDir {
 
 impl ::launcher::parser::traits::Action for DeleteDir {
     fn execute(&mut self, params: ::launcher::parser::ParameterPacket) -> ::launcher::parser::ResponseType {
-        use rustc_serialize::base64::FromBase64;
 
         let mut tokens = ::launcher::parser::helper::tokenise_path(&self.dir_path, false);
         let dir_to_delete = try!(tokens.pop().ok_or(::errors::LauncherError::InvalidPath));

--- a/src/launcher/parser/nfs/mod.rs
+++ b/src/launcher/parser/nfs/mod.rs
@@ -72,7 +72,7 @@ fn get_action<D>(action_str: &str, version: f32, decoder: &mut D) -> Result<Box<
             _   => return version_err,
         },
         "modify-file" => match version {
-            1.0 => unimplemented!(),
+            1.0 => Box::new(try!(parse_result!(modify_file_v1_0::ModifyFile::decode(decoder), ""))),
             _   => return version_err,
         },
         "get-file" => match version {

--- a/src/launcher/parser/nfs/mod.rs
+++ b/src/launcher/parser/nfs/mod.rs
@@ -72,7 +72,7 @@ fn get_action<D>(action_str: &str, version: f32, decoder: &mut D) -> Result<Box<
             _   => return version_err,
         },
         "modify-file" => match version {
-            1.0 => Box::new(try!(parse_result!(modify_file_v1_0::ModifyFile::decode(decoder), ""))),
+            1.0 => Box::new(try!(parse_result!(decoder.read_struct_field("data", 0, |d| modify_file_v1_0::ModifyFile::decode(d)), ""))),
             _   => return version_err,
         },
         "get-file" => match version {

--- a/src/launcher/parser/nfs/modify_dir_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_dir_v1_0.rs
@@ -74,7 +74,7 @@ impl ::rustc_serialize::Decodable for OptionalParams {
     fn decode<D>(decoder: &mut D) -> Result<Self, D::Error>
                                      where D: ::rustc_serialize::Decoder {
         Ok(OptionalParams {
-            name         : decoder.read_struct_field("dir_path", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            name         : decoder.read_struct_field("name", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             user_metadata: decoder.read_struct_field("user_metadata", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
         })
     }

--- a/src/launcher/parser/nfs/modify_dir_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_dir_v1_0.rs
@@ -41,7 +41,21 @@ impl ::launcher::parser::traits::Action for ModifyDir {
                                                                                         &tokens,
                                                                                         Some(start_dir_key)));
 
-        unimplemented!();
+        if !(self.new_values.name.is_some() || self.new_values.user_metadata.is_some()) {
+            return Err(::errors::LauncherError::Unexpected("new_values could not be parsed or the field is empty".to_string()));
+        }
+
+        let directory_helper = ::safe_nfs::helper::directory_helper::DirectoryHelper::new(params.client);
+        if let Some(ref name) = self.new_values.name {
+            dir_to_modify.get_mut_metadata().set_name(name.clone());
+        }
+
+        if let Some(ref metadata_base64) = self.new_values.user_metadata {
+            let metadata = try!(parse_result!(metadata_base64.from_base64(), "Failed to convert from base64"));
+            dir_to_modify.get_mut_metadata().set_user_metadata(metadata);
+        }
+
+        let _ = try!(directory_helper.update(&dir_to_modify));
 
         Ok(None)
     }
@@ -49,24 +63,16 @@ impl ::launcher::parser::traits::Action for ModifyDir {
 
 #[derive(Debug)]
 struct OptionalParams {
-    pub name                  : Option<String>,
-    pub is_private            : Option<bool>,
-    pub is_versioned          : Option<bool>,
-    pub user_metadata         : Option<String>,
-    pub modification_time_sec : Option<i64>,
-    pub modification_time_nsec: Option<i64>,
+    pub name         : Option<String>,
+    pub user_metadata: Option<String>,
 }
 
 impl ::rustc_serialize::Decodable for OptionalParams {
     fn decode<D>(decoder: &mut D) -> Result<Self, D::Error>
                                      where D: ::rustc_serialize::Decoder {
         Ok(OptionalParams {
-            name: decoder.read_struct_field("dir_path", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            is_private: decoder.read_struct_field("is_private", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            is_versioned: decoder.read_struct_field("is_versioned", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            name         : decoder.read_struct_field("dir_path", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             user_metadata: decoder.read_struct_field("user_metadata", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            modification_time_sec: decoder.read_struct_field("modification_time_sec", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            modification_time_nsec: decoder.read_struct_field("modification_time_sec", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
         })
     }
 }

--- a/src/launcher/parser/nfs/modify_dir_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_dir_v1_0.rs
@@ -61,7 +61,7 @@ impl ::launcher::parser::traits::Action for ModifyDir {
     }
 }
 // TODO Below are the deviations from the RFC parameters
-// modified time stamp cann not be updated via NFS API
+// modified time stamp can not be updated via NFS API
 // NFS Api does not permit changing the private to public accesslevel
 // versioning can not be changed too
 #[derive(Debug)]

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -104,7 +104,7 @@ impl ::rustc_serialize::Decodable for OptionalParams {
     fn decode<D>(decoder: &mut D) -> Result<Self, D::Error>
                                      where D: ::rustc_serialize::Decoder {
         Ok(OptionalParams {
-            name         : decoder.read_struct_field("dir_path", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            name         : decoder.read_struct_field("name", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             content      : decoder.read_struct_field("content", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             user_metadata: decoder.read_struct_field("user_metadata", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
         })
@@ -123,7 +123,7 @@ impl ::rustc_serialize::Decodable for FileContentParams {
                                      where D: ::rustc_serialize::Decoder {
         Ok(FileContentParams {
             offset: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            modify: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            modify: decoder.read_struct_field("modify", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             bytes : decoder.read_struct_field("bytes", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
         })
     }

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -30,7 +30,6 @@ impl ::launcher::parser::traits::Action for ModifyFile {
             return Err(::errors::LauncherError::PermissionDenied)
         }
 
-
         if self.new_values.name.is_none() &&
            self.new_values.user_metadata.is_none() &&
            self.new_values.content.is_none() {
@@ -58,7 +57,7 @@ impl ::launcher::parser::traits::Action for ModifyFile {
             file.get_mut_metadata().set_name(name.clone());
             metadata_updated = true;
         }
-        
+
         if let Some(ref metadata_base64) = self.new_values.user_metadata {
             let metadata = try!(parse_result!(metadata_base64.from_base64(), "Failed to convert from base64"));
             file.get_mut_metadata().set_user_metadata(metadata);

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -1,0 +1,127 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+#[derive(RustcDecodable, Debug)]
+pub struct ModifyFile {
+    is_path_shared : bool,
+    path           : String,
+    new_values     : OptionalParams,
+}
+
+impl ::launcher::parser::traits::Action for ModifyFile {
+    fn execute(&mut self, params: ::launcher::parser::ParameterPacket) -> ::launcher::parser::ResponseType {
+        use rustc_serialize::base64::FromBase64;
+
+        if self.is_path_shared && !*eval_result!(params.safe_drive_access.lock()) {
+            return Err(::errors::LauncherError::PermissionDenied)
+        }
+
+        let start_dir_key = if self.is_path_shared {
+            &params.safe_drive_dir_key
+        } else {
+            &params.app_root_dir_key
+        };
+
+        let mut tokens = ::launcher::parser::helper::tokenise_path(&self.path, false);
+        let file_name = try!(tokens.pop().ok_or(::errors::LauncherError::InvalidPath));
+        let mut dir_of_file = try!(::launcher::parser::helper::get_final_subdirectory(params.client.clone(),
+                                                                                      &tokens,
+                                                                                      Some(start_dir_key)));
+
+        let mut file= try!(dir_of_file.find_file(&file_name).map(|file| file.clone()).ok_or(::errors::LauncherError::InvalidPath));
+
+        if self.new_values.name.is_none() &&
+           self.new_values.user_metadata.is_none() &&
+           self.new_values.content.is_none() {
+            return Err(::errors::LauncherError::SpecificParseError("new_values caould not be parsed or new_values is empty".to_string()));
+        }
+
+        let file_helper = ::safe_nfs::helper::file_helper::FileHelper::new(params.client);
+
+        let mut metadata_updated = false;
+        if let Some(ref name) = self.new_values.name {
+            file.get_mut_metadata().set_name(name.clone());
+            metadata_updated = true;
+        }
+
+        if let Some(ref metadata) = self.new_values.user_metadata {
+            file.get_mut_metadata().set_user_metadata(metadata.clone());
+            metadata_updated = true;
+        }
+
+        if metadata_updated {
+            let _ = try!(file_helper.update_metadata(file.clone(), &mut dir_of_file));
+        }
+
+        if let Some(ref file_content_params) = self.new_values.content {
+            let mut mode = ::safe_nfs::helper::writer::Mode::Overwrite;
+            if let Some(modify) = file_content_params.modify {
+                if modify {
+                    mode = ::safe_nfs::helper::writer::Mode::Modify;
+                }
+            };
+            let offset = match mode {
+                ::safe_nfs::helper::writer::Mode::Overwrite => 0,
+                ::safe_nfs::helper::writer::Mode::Modify    => file_content_params.offset.map_or(0, |v| v)
+            };
+            if let Some(ref data) = file_content_params.bytes {
+                let mut writter = try!(file_helper.update_content(file.clone(), mode, dir_of_file));
+                writter.write(&data[..], offset);
+            } else {
+                return Err(::errors::LauncherError::Unexpected("Empty bytes received for updating file".to_string()));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+struct OptionalParams {
+    pub name                  : Option<String>,
+    pub content               : Option<FileContentParams>,
+    pub user_metadata         : Option<Vec<u8>>,
+}
+
+impl ::rustc_serialize::Decodable for OptionalParams {
+    fn decode<D>(decoder: &mut D) -> Result<Self, D::Error>
+                                     where D: ::rustc_serialize::Decoder {
+        Ok(OptionalParams {
+            name         : decoder.read_struct_field("dir_path", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            content      : decoder.read_struct_field("content", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            user_metadata: decoder.read_struct_field("user_metadata", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct FileContentParams {
+    pub offset : Option<u64>,
+    pub modify : Option<bool>,
+    pub bytes  : Option<Vec<u8>>,
+}
+
+impl ::rustc_serialize::Decodable for FileContentParams {
+    fn decode<D>(decoder: &mut D) -> Result<Self, D::Error>
+                                     where D: ::rustc_serialize::Decoder {
+        Ok(FileContentParams {
+            offset: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            modify: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            bytes: decoder.read_struct_field("bytes", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+        })
+    }
+}

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -17,9 +17,9 @@
 
 #[derive(RustcDecodable, Debug)]
 pub struct ModifyFile {
-    path           : String,
-    new_values     : OptionalParams,
-    is_path_shared : bool,
+    path          : String,
+    new_values    : OptionalParams,
+    is_path_shared: bool,
 }
 
 impl ::launcher::parser::traits::Action for ModifyFile {

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -114,9 +114,9 @@ impl ::rustc_serialize::Decodable for OptionalParams {
 
 #[derive(Debug)]
 struct FileContentParams {
-    pub offset : Option<u64>,
-    pub modify : Option<bool>,
-    pub bytes  : Option<String>,
+    pub offset: Option<u64>,
+    pub modify: Option<bool>,
+    pub bytes : Option<String>,
 }
 
 impl ::rustc_serialize::Decodable for FileContentParams {
@@ -125,7 +125,7 @@ impl ::rustc_serialize::Decodable for FileContentParams {
         Ok(FileContentParams {
             offset: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
             modify: decoder.read_struct_field("offset", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
-            bytes: decoder.read_struct_field("bytes", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
+            bytes : decoder.read_struct_field("bytes", 0, |d| ::rustc_serialize::Decodable::decode(d)).ok(),
         })
     }
 }

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -30,6 +30,12 @@ impl ::launcher::parser::traits::Action for ModifyFile {
             return Err(::errors::LauncherError::PermissionDenied)
         }
 
+        if self.new_values.name.is_none() &&
+           self.new_values.user_metadata.is_none() &&
+           self.new_values.content.is_none() {
+            return Err(::errors::LauncherError::from("Optional parameters could not be parsed"));
+        }
+
         let start_dir_key = if self.is_path_shared {
             &params.safe_drive_dir_key
         } else {
@@ -43,12 +49,6 @@ impl ::launcher::parser::traits::Action for ModifyFile {
                                                                                       Some(start_dir_key)));
 
         let mut file= try!(dir_of_file.find_file(&file_name).map(|file| file.clone()).ok_or(::errors::LauncherError::InvalidPath));
-
-        if self.new_values.name.is_none() &&
-           self.new_values.user_metadata.is_none() &&
-           self.new_values.content.is_none() {
-            return Err(::errors::LauncherError::SpecificParseError("new_values could not be parsed or new_values is empty".to_string()));
-        }
 
         let file_helper = ::safe_nfs::helper::file_helper::FileHelper::new(params.client);
 
@@ -86,7 +86,7 @@ impl ::launcher::parser::traits::Action for ModifyFile {
                 writer.write(&bytes[..], offset);
                 let _ = try!(writer.close());
             } else {
-                return Err(::errors::LauncherError::Unexpected("Empty bytes received for updating file".to_string()));
+                return Err(::errors::LauncherError::from("Empty bytes received for updating file"));
             }
         }
 

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -95,9 +95,9 @@ impl ::launcher::parser::traits::Action for ModifyFile {
 
 #[derive(Debug)]
 struct OptionalParams {
-    pub name                  : Option<String>,
-    pub content               : Option<FileContentParams>,
-    pub user_metadata         : Option<String>,
+    pub name         : Option<String>,
+    pub content      : Option<FileContentParams>,
+    pub user_metadata: Option<String>,
 }
 
 impl ::rustc_serialize::Decodable for OptionalParams {

--- a/src/launcher/parser/nfs/modify_file_v1_0.rs
+++ b/src/launcher/parser/nfs/modify_file_v1_0.rs
@@ -48,7 +48,7 @@ impl ::launcher::parser::traits::Action for ModifyFile {
                                                                                       &tokens,
                                                                                       Some(start_dir_key)));
 
-        let mut file= try!(dir_of_file.find_file(&file_name).map(|file| file.clone()).ok_or(::errors::LauncherError::InvalidPath));
+        let mut file = try!(dir_of_file.find_file(&file_name).map(|file| file.clone()).ok_or(::errors::LauncherError::InvalidPath));
 
         let file_helper = ::safe_nfs::helper::file_helper::FileHelper::new(params.client);
 
@@ -65,7 +65,6 @@ impl ::launcher::parser::traits::Action for ModifyFile {
         }
 
         if metadata_updated {
-
             let _ = try!(file_helper.update_metadata(file.clone(), &mut dir_of_file));
         }
 


### PR DESCRIPTION
Had to include `modify` variable in request json format. This variable corresponds to the MODE enum in `nfs`. if the modify is set to true, then the bytes passed will be modified from the start range, else the data is completely overwritten.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_launcher/17)
<!-- Reviewable:end -->
