### PR TITLE
fix/login_error: resolve network disconnected on wrong credentials

### DIFF
--- a/app/api/ffi/mod/auth.js
+++ b/app/api/ffi/mod/auth.js
@@ -81,7 +81,6 @@ var register = function(lib, request, observer) {
     return util.sendError(request.id, 999, e.message());
   }
   if (res !== 0) {
-    util.sendConnectionStatus(1, true);
     return util.sendError(request.id, res);
   }
   registeredClientHandle = regClient.deref();
@@ -107,7 +106,6 @@ var login = function(lib, request, observer) {
     return util.sendError(request.id, 999, e.toString());
   }
   if (res !== 0) {
-    util.sendConnectionStatus(1, true);
     return util.sendError(request.id, res);
   }
   registeredClientHandle = regClient.deref();


### PR DESCRIPTION
Only the unauthorsied client created at the start would need to handle the network connection failure. The registered client creation should not be concerned about the network connection lost while login/register. Network failure will be passed to the unregistered client observer which is sufficient for handling the error on UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_launcher/183)
<!-- Reviewable:end -->
