### PR TITLE
new domain name of public forum as of august 2016

### DIFF
--- a/app/views/tab/help.html
+++ b/app/views/tab/help.html
@@ -22,7 +22,7 @@
     </ul>
     <h3 class="title">Discussions:</h3>
     <p class="p">
-      You can join the discussion on the <a href="#" ng-click="openExternal($event, 'https://forum.safenetwork.io')">Community forum</a>.
+      You can join the discussion on the <a href="#" ng-click="openExternal($event, 'https://safenetforum.org')">Community forum</a>.
       If you'd like to contribute to the code or have found any issues, you can find us on <a href="#" ng-click="openExternal($event, 'https://github.com/maidsafe/safe_launcher/issues')">GitHub</a>.
     </p>
   </div>


### PR DESCRIPTION
represent proper destination link of public user forum
as of august 2016, we have switched over to
https://safenetforum.org

from before maidsafe.org and forum.safenetwork.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_launcher/233)
<!-- Reviewable:end -->
