### PR TITLE
Fix usage of Node FFI libs

### DIFF
--- a/app/ffi/api/appendable_data.js
+++ b/app/ffi/api/appendable_data.js
@@ -8,6 +8,7 @@ import { FILTER_TYPE } from '../model/enum';
 import log from '../../logger/log';
 
 const int32 = ref.types.int32;
+const Int = ref.types.int;
 const u8 = ref.types.uint8;
 const u64 = ref.types.uint64;
 const Void = ref.types.void;
@@ -23,8 +24,6 @@ const boolPointer = ref.refType(bool);
 const size_tPointer = ref.refType(size_t);
 
 const Ffi_FilterType = new Enum({ BlackList: 0, WhiteList: 1 });
-
-const filterTypePointer = ref.refType(Ffi_FilterType);
 /* eslint-enable camelcase */
 
 class AppendableData extends FfiApi {
@@ -57,7 +56,7 @@ class AppendableData extends FfiApi {
       appendable_data_clear_deleted_data: [int32, [u64]],
       appendable_data_remove_nth_deleted_data: [int32, [u64, size_t]],
       appendable_data_remove_from_filter: [int32, [u64, u64]],
-      appendable_data_filter_type: [int32, [u64, filterTypePointer]],
+      appendable_data_filter_type: [int32, [u64, ref.refType(Int)]],
       appendable_data_num_of_filter_keys: [int32, [u64, size_tPointer]],
       appendable_data_nth_filter_key: [int32, [u64, size_t, u64Pointer]]
       // 'appendable_data_delete': [int32, [AppHandle, u64]]

--- a/app/ffi/api/dns.js
+++ b/app/ffi/api/dns.js
@@ -154,7 +154,7 @@ class DNS extends FfiApi {
 
   listServices(app, longName) {
     return new Promise((resolve, reject) => {
-      const listHandle = ref.alloc(PointerToVoidPointer);
+      const listHandle = ref.alloc(PointerHandle);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           log.error(`FFI :: DNS :: List service :: ${err || res}`);

--- a/app/ffi/api/dns.js
+++ b/app/ffi/api/dns.js
@@ -209,17 +209,15 @@ class DNS extends FfiApi {
 
   getFileMetadata(app, longName, serviceName, path) {
     return new Promise((resolve, reject) => {
-      const fileMetadataRefRef = ref.alloc(PointerToFileMetadataPointer);
+      const fileMetadataHandle = ref.alloc(FileMetadataHandle);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           log.error(`FFI :: DNS :: Get file metadata :: ${err || res}`);
           return reject(err || res);
         }
         try {
-          const fileMetadataHandle = fileMetadataRefRef.deref();
-          const fileMetadataRef = ref.alloc(FileMetadataHandle, fileMetadataHandle).deref();
-          const metadata = derefFileMetadataStruct(fileMetadataRef.deref());
-          this.safeCore.file_metadata_drop.async(fileMetadataHandle, () => {});
+          const metadata = derefFileMetadataStruct(new FileMetadata(fileMetadataHandle.deref()));
+          this.safeCore.file_metadata_drop.async(fileMetadataHandle.deref(), () => {});
           resolve(metadata);
         } catch (e) {
           log.warn(`FFI :: DNS :: Get file metadata :: Caught exception - 
@@ -233,7 +231,7 @@ class DNS extends FfiApi {
         longNameBuffer, longNameBuffer.length,
         serviceNameBuffer, serviceNameBuffer.length,
         pathBuffer, pathBuffer.length,
-        fileMetadataRefRef, onResult);
+        fileMetadataHandle, onResult);
     });
   }
 

--- a/app/ffi/api/dns.js
+++ b/app/ffi/api/dns.js
@@ -171,20 +171,20 @@ class DNS extends FfiApi {
 
   getServiceDirectory(app, longName, serviceName) {
     return new Promise((resolve, reject) => {
-      const directoryDetailsHandlePointer = ref.alloc(PointerToVoidPointer);
+      const directoryDetailsHandle = ref.alloc(PointerHandle);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           log.error(`FFI :: DNS :: Get service directory :: ${err || res}`);
           return reject(err || res);
         }
-        resolve(nfs.derefDirectoryDetailsHandle(directoryDetailsHandlePointer.deref()));
+        resolve(nfs.derefDirectoryDetailsHandle(directoryDetailsHandle.deref()));
       };
       const longNameBuffer = new Buffer(longName);
       const serviceNameBuffer = new Buffer(serviceName);
       this.safeCore.dns_get_service_dir.async(appManager.getHandle(app),
         longNameBuffer, longNameBuffer.length,
         serviceNameBuffer, serviceNameBuffer.length,
-        directoryDetailsHandlePointer, onResult);
+        directoryDetailsHandle, onResult);
     });
   }
 

--- a/app/ffi/api/dns.js
+++ b/app/ffi/api/dns.js
@@ -75,17 +75,16 @@ class DNS extends FfiApi {
       return error('Application parameter is mandatory');
     }
     return new Promise((resolve, reject) => {
-      const listHandlePointer = ref.alloc(PointerToVoidPointer);
+      const listHandle = ref.alloc(PointerHandle);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           log.error(`FFI :: DNS :: List longname :: ${err || res}`);
           return reject(err || res);
         }
-        const listHandle = listHandlePointer.deref();
-        resolve(consumeStringListHandle(this.safeCore, listHandle));
+        resolve(consumeStringListHandle(this.safeCore, listHandle.deref()));
       };
       this.safeCore.dns_get_long_names.async(appManager.getHandle(app),
-        listHandlePointer, onResult);
+        listHandle, onResult);
     });
   }
 

--- a/app/ffi/api/nfs.js
+++ b/app/ffi/api/nfs.js
@@ -430,7 +430,7 @@ class NFS extends FfiApi {
       return error('Invalid parameters');
     }
     const self = this;
-    const fileMetadataPointerHandle = ref.alloc(PointerToFileMetadataPointer);
+    const fileMetadataHandle = ref.alloc(FileMetadataHandle);
     const executor = (resolve, reject) => {
       const onResult = (err, res) => {
         if (err || res !== 0) {
@@ -438,10 +438,8 @@ class NFS extends FfiApi {
           return reject(err || res);
         }
         try {
-          const fileMetadataHandle = fileMetadataPointerHandle.deref();
-          const fileMetadataRef = ref.alloc(FileMetadataHandle, fileMetadataHandle).deref();
-          const metadata = derefFileMetadataStruct(fileMetadataRef.deref());
-          self.safeCore.file_metadata_drop.async(fileMetadataHandle, () => {});
+          const metadata = derefFileMetadataStruct(new FileMetadata(fileMetadataHandle.deref()));
+          self.safeCore.file_metadata_drop.async(fileMetadataHandle.deref(), () => {});
           resolve(metadata);
         } catch (e) {
           log.error(`FFI :: NFS :: Get file metadata :: Caught exception - 
@@ -451,7 +449,7 @@ class NFS extends FfiApi {
 
       const pathBuff = new Buffer(path);
       self.safeCore.nfs_get_file_metadata.async(appManager.getHandle(app),
-        pathBuff, pathBuff.length, isShared, fileMetadataPointerHandle, onResult);
+        pathBuff, pathBuff.length, isShared, fileMetadataHandle, onResult);
     };
     return new Promise(executor);
   }

--- a/app/ffi/api/nfs.js
+++ b/app/ffi/api/nfs.js
@@ -290,14 +290,14 @@ class NFS extends FfiApi {
     }
     const self = this;
     const executor = (resolve, reject) => {
-      const writerVoidPointer = ref.alloc(PointerToVoidPointer);
+      const writerPointer = ref.alloc(VoidPointerHandle);
       const onResult = (err, res) => {
         if (err || res !== 0) {
           log.error(`FFI :: NFS :: Create file :: ${err || res}`);
           return reject(err || res);
         }
         const key = { writerId: uuid.v4() };
-        self.writerHolder.set(key, writerVoidPointer.deref());
+        self.writerHolder.set(key, writerPointer.deref());
         resolve(key);
       };
       const filePathBuff = new Buffer(filePath);
@@ -309,7 +309,7 @@ class NFS extends FfiApi {
         filePathBuff, filePathBuff.length,
         metadataBuff, (metadataBuff ? metadataBuff.length : 0),
         isShared,
-        writerVoidPointer, onResult);
+        writerPointer, onResult);
     };
     return new Promise(executor);
   }

--- a/app/ffi/api/nfs.js
+++ b/app/ffi/api/nfs.js
@@ -199,7 +199,7 @@ class NFS extends FfiApi {
       return error('Invalid parameters');
     }
     const self = this;
-    const dirDetailsHandle = ref.alloc(PointerToVoidPointer);
+    const dirDetailsHandle = ref.alloc(VoidPointerHandle);
 
     const executor = (resolve, reject) => {
       const onResult = (err, res) => {

--- a/app/ffi/util/utils.js
+++ b/app/ffi/util/utils.js
@@ -77,6 +77,17 @@ export const derefFileMetadataStruct = (metadataStruct) => {
   };
 };
 
+export const safeBufferGetter = (obj, ptrFieldName, lenFieldName) => {
+  let computedLenFieldName = lenFieldName;
+  if (!lenFieldName) {
+    computedLenFieldName = `${ptrFieldName}_len`;
+  }
+  if (obj[computedLenFieldName] === 0) {
+    return Buffer.alloc(0);
+  }
+  return Buffer.concat([ref.reinterpret(obj[ptrFieldName], obj[computedLenFieldName])]);
+};
+
 export const derefDirectoryMetadataStruct = (metadataStruct) => {
   let dirName = '';
   let dirMetadata = '';


### PR DESCRIPTION
C pointers have their own merit to cause confusion. On top of that,
NodeJS's `ref` package will add its own confusion.

If you are only traversing pointers, then the rules are pretty similar
to C. `obj.ref()` will "get the address of the pointer" (actually it'll
allocate a new pointer whose value is the address of the old pointer)
and `obj.deref()` will dereference the pointer (i.e. get the pointee).

So, if `foo` was created calling `ref.alloc(ref.refType('int'))`, you
can treat as if it were a C `int*`. However, you always manipulate
references and `foo.deref()` will hold not an `int`, but a `Buffer`
whose size is the size of an `int` and whose contents represent the
value contained by this `int`. To convert the `Buffer` into a JS Number
value, you need to call `deref` once more (i.e. `foo.deref().deref()`).

The big confusion added by the `ref` package is the fact that you always
pass the address of the buffer to the C function. If `foo` is a
"pointer", the address of the pointer (represented by NodeJS as a
`Buffer` size_t-sized), and not the memory address being hold by the
pointer, is passed when you call a C function.

There is also the confusion of `ref-struct` package.
`ref.refType(FileDetails)` will create a type without the helper
functions present in `FileDetails`. So you need to create a new
`FileDetails` instance passing the backing `Buffer` as argument once you
obtain the `FileDetails` navigating through references.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_launcher/255)

<!-- Reviewable:end -->
