### PR TITLE
fix/type_tag_miss_match: update typeTag miss match in get structured id hanle

### DIFF
--- a/app/ffi/api/data_id.js
+++ b/app/ffi/api/data_id.js
@@ -32,7 +32,7 @@ class DataId extends FfiApi {
     });
   }
 
-  getStructuredDataHandle(typeTag = 501, name) {
+  getStructuredDataHandle(typeTag = 500, name) {
     return new Promise((resolve, reject) => {
       const handleRef = ref.alloc(u64);
       const onResult = (err, res) => {

--- a/app/server/controllers/appendable_data.js
+++ b/app/server/controllers/appendable_data.js
@@ -160,7 +160,6 @@ export const getMetadata = async(req, res) => {
     const deletedDataLength = await appendableData.getLength(handleId, true);
     const filterLength = await appendableData.getFilterLength(handleId);
     const metadata = {
-      handleId,
       isOwner,
       version,
       filterType,

--- a/test/api/appendable_data.spec.js
+++ b/test/api/appendable_data.spec.js
@@ -284,7 +284,6 @@ describe('Appendable data', () => {
         .then(res => {
           should(res.status).be.equal(200);
           should(res.data).have.keys(
-            'handleId',
             'isOwner',
             'version',
             'filterType',


### PR DESCRIPTION
Updated typeTag miss match in get structured data Id handle.
Handle Id removed from response of Get metadata request in Appendable data and also updated the test cases.